### PR TITLE
feat: Configure package for GitHub Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,47 @@
-# Invoza CLI (invoxa-cli)
+# Invoza CLI (@zeta-develop/invoxa-cli)
 
-This CLI tool scaffolds a new Invoza project.
+This CLI tool scaffolds a new Invoza project. It is published on GitHub Packages.
 
-## Installation
+## Installation from GitHub Packages
 
-You can install this tool globally using npm (once published):
+To install this package from GitHub Packages, you or your users will need to configure npm to use the GitHub Packages registry for the `@zeta-develop` scope.
 
-```bash
-npm install -g invoxa-cli
-```
-Then, you can run the command:
-```bash
-invoxa my-new-project
-```
+1.  **Authenticate to GitHub Packages:**
+    Ensure you are authenticated to GitHub Packages. This usually involves having a Personal Access Token (PAT) with at least `read:packages` scope.
 
-Alternatively, for one-time use without global installation, you can use `npx`. `npx` will use the command specified in the `bin` of `package.json` (which is `invoxa` for this package):
+2.  **Configure `.npmrc`:**
+    Add the following lines to your user-level `.npmrc` file (usually at `~/.npmrc`) or a project-level `.npmrc` file:
+    ```
+    @zeta-develop:registry=https://npm.pkg.github.com/
+    //npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
+    ```
+    Replace `YOUR_GITHUB_PAT` with your GitHub Personal Access Token.
 
-```bash
-npx invoxa-cli my-awesome-project
-```
+3.  **Install the package:**
+    Now you can install the package:
+    For global installation:
+    ```bash
+    npm install -g @zeta-develop/invoxa-cli
+    ```
+    Then, you can run the command (which is `invoxa` as defined in `package.json` `bin`):
+    ```bash
+    invoxa my-new-project
+    ```
+    To use with `npx` (this also requires the `.npmrc` configuration if the package is not yet cached or public on npmjs.org):
+    ```bash
+    npx @zeta-develop/invoxa-cli my-project-name
+    ```
 
 ## Usage
 
 To generate a new Invoza project, navigate to the directory where you want to create the project's parent folder and run:
 
-If using `npx`:
+If using `npx` (after configuring `.npmrc` as per installation):
 ```bash
-npx invoxa-cli my-new-project
+npx @zeta-develop/invoxa-cli my-new-project
 ```
 
-Or, if you have installed `invoxa-cli` globally:
+Or, if you have installed `@zeta-develop/invoxa-cli` globally (after configuring `.npmrc`):
 ```bash
 invoxa my-new-project
 ```
@@ -43,7 +55,7 @@ This will create a new directory named `my-new-project` (or your chosen project 
 1.  **Clone the repository:**
     ```bash
     git clone <your-repo-url> # Replace <your-repo-url> with the actual URL
-    cd invoxa-cli
+    cd invoxa-cli # The directory name of the cloned repo
     ```
 2.  **Install dependencies for the CLI tool itself:**
     This step is crucial to install `fs-extra` and other dependencies.
@@ -55,7 +67,7 @@ This will create a new directory named `my-new-project` (or your chosen project 
     ```bash
     npm link
     ```
-    Verify by typing `invoxa` in a new terminal tab/window; it should show the help message if no project name is provided.
+    Verify by typing `invoxa` in a new terminal tab/window; it should show the help message if no project name is provided, or version info.
 
 4.  **Test the command:**
     Navigate to a *different* directory where you want to create your test project. For example:
@@ -78,7 +90,26 @@ This will create a new directory named `my-new-project` (or your chosen project 
     ```bash
     npm unlink
     ```
-    This removes the global link for `invoxa` that was pointing to this local project. If you want to be sure, you can also try `npm uninstall -g invoxa-cli` if you previously installed it globally for testing.
+    This removes the global link for `invoxa` that was pointing to this local project. If you also installed it globally for testing from a registry, you might need `npm uninstall -g @zeta-develop/invoxa-cli`.
+
+## Publishing to GitHub Packages
+
+This package is configured to be published to GitHub Packages under the `@zeta-develop` scope.
+
+1.  **Authenticate with GitHub Packages:**
+    You need to authenticate with npm using a Personal Access Token (PAT) that has the `read:packages` and `write:packages` scopes.
+    ```bash
+    npm login --registry=https://npm.pkg.github.com
+    ```
+    Enter your GitHub username and use the PAT as your password.
+
+2.  **Publish the package:**
+    Increment the version in `package.json` as needed (e.g., `npm version patch`).
+    Then, publish the package using:
+    ```bash
+    npm publish
+    ```
+    Npm will use the `publishConfig` in `package.json` to route the package to GitHub Packages.
 
 ## Project Template
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const projectName = process.argv[2];
 
 if (!projectName) {
   console.error('Error: Project name is required.');
-  console.log('Usage: npx invoxa <project-name>');
+  console.log('Usage: npx @zeta-develop/invoxa-cli <project-name>');
   process.exit(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "invoxa-cli",
+  "name": "@zeta-develop/invoxa-cli",
   "version": "0.1.0",
   "description": "CLI tool to generate a new Invoza project",
   "main": "index.js",
@@ -18,5 +18,12 @@
   "license": "ISC",
   "dependencies": {
     "fs-extra": "^10.0.0"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/zeta-develop/invoxa-cli.git"
   }
 }


### PR DESCRIPTION
This commit updates the `invoxa-cli` package to support publishing to and installation from GitHub Packages under the `@zeta-develop` scope.

Key changes:

- **package.json**:
  - Renamed to `@zeta-develop/invoxa-cli`.
  - Added `publishConfig` to point the registry to `https://npm.pkg.github.com`.
  - Added the repository URL.

- **index.js**:
  - Updated the `npx` usage example in the help message to `npx @zeta-develop/invoxa-cli <project-name>`.

- **README.md**:
  - Updated all package name references to `@zeta-develop/invoxa-cli`.
  - Added detailed sections on:
    - Publishing to GitHub Packages (authentication, `npm publish`).
    - Installing from GitHub Packages (configuring `.npmrc` for the `@zeta-develop` scope, `npm install @zeta-develop/invoxa-cli`, and `npx @zeta-develop/invoxa-cli <project-name>`).
  - Revised local development and testing instructions to align with the scoped package, while noting the `invoxa` command remains available via `npm link`.