### PR TITLE
feat: Implement interactive CLI and module installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Invoza CLI (invoxa)
 
-This CLI tool scaffolds a new Invoza project.
+This CLI tool scaffolds a new Invoza project and helps manage its modules.
 
 ## Installation
 
@@ -8,80 +8,123 @@ You can install this tool globally using npm:
 ```bash
 npm install -g invoxa
 ```
-Then, you can run the command:
+
+Alternatively, for one-time use without global installation (recommended to ensure you're using the latest version):
 ```bash
-invoxa my-new-project
+npx invoxa@latest <command>
 ```
+(Replace `<command>` with the specific invoxa command you want to run, e.g., `my-project-name` or `install:pterodactyl`)
 
-Alternatively, you can install it as a development dependency in your project:
-```bash
-npm install --save-dev invoxa
-```
+## Getting Started: Creating a New Invoza Project
 
-For one-time use without global or local installation, you can use `npx` (which is recommended to ensure you're using the latest version):
-```bash
-npx invoxa@latest my-awesome-project
-```
+To create a new Invoza project (main application):
 
-## Usage
+1.  Navigate to the directory where you want to create the project's parent folder.
+2.  Run the command:
+    *   **Directly with project name:**
+        ```bash
+        invoxa my-new-project
+        ```
+        (Or `npx invoxa@latest my-new-project`)
+    *   **Interactively (prompts for project name):**
+        ```bash
+        invoxa
+        ```
+        (Or `npx invoxa@latest`)
 
-To generate a new Invoza project, navigate to the directory where you want to create the project's parent folder and run:
+This command scaffolds the main Invoza application from the CLI's internal `template/invoxa/` directory into a new folder named `my-new-project` (or your chosen name). It also creates an empty `.invoza-project-marker` file in the root of your new project, which helps the CLI identify it as an Invoza project.
 
-If using `npx` (recommended for always using the latest version):
-```bash
-npx invoxa@latest my-new-project
-```
+**Note:** The project creation will exit if a directory with the chosen project name already exists in the current location.
 
-Or, if you have installed `invoxa` globally:
-```bash
-invoxa my-new-project
-```
+## Managing an Existing Invoza Project
 
-This will create a new directory named `my-new-project` (or your chosen project name) inside the current directory, and copy the basic Invoza project template into it.
+Once an Invoza project is created:
 
-**Note:** The command will exit if a directory with the chosen project name already exists in the current location.
+1.  Navigate into your project's root directory:
+    ```bash
+    cd my-new-project
+    ```
+2.  Run `invoxa` without any arguments:
+    ```bash
+    invoxa
+    ```
+This will open an interactive menu to help you manage your project. Current options include:
+    *   **Install a new module:** Lets you choose from available modules to install into your project.
+    *   **Exit:** Closes the interactive menu.
+
+## Installing Modules
+
+Modules provide additional functionalities and are installed into the `<your-project-root>/modules/` directory. You can install modules in two ways:
+
+1.  **Via Interactive Menu:**
+    *   Run `invoxa` from your project's root directory.
+    *   Choose the "Install a new module" option.
+    *   Select the desired module from the list of available modules.
+
+2.  **Via Direct Command:**
+    *   From within your project's root directory (or any subdirectory), run:
+        ```bash
+        invoxa install:<module-name>
+        ```
+        Example: `invoxa install:pterodactyl`
+    *   Replace `<module-name>` with the name of the module you want to install (must match a directory name in `template/modules/`).
+
+## CLI Template Structure (For CLI Developers)
+
+This section describes the template structure within the `invoxa-cli` package itself, which you (as the developer of this CLI tool) would modify to change what gets scaffolded.
+
+*   **`template/invoxa/`**:
+    This directory should contain the complete file structure for the main Invoza (Remix.run) application. When a user runs `invoxa <project-name>` or `invoxa` (and provides a name), the contents of this directory are copied to the new project.
+    *You should place your core Remix.run project template here.*
+
+*   **`template/modules/`**:
+    This is the parent directory for all installable modules.
+
+*   **`template/modules/<module-name>/`**:
+    Each subdirectory within `template/modules/` represents an installable module. For example, to create a module named "pterodactyl", you would create a directory `template/modules/pterodactyl/` and place all its files and subdirectories within it.
+    The name of the directory (e.g., "pterodactyl") is the `<module-name>` used in `invoxa install:<module-name>` and will be listed in the interactive menu.
+
+## Generated Project Structure
+
+A newly generated Invoza project will have:
+*   The contents of the `template/invoxa/` (your core application).
+*   An empty `.invoza-project-marker` file in its root.
+*   A `modules/` directory (created when you install the first module).
 
 ## Development (Testing Locally)
 
-1.  **Clone the repository:**
+1.  **Clone the `invoxa-cli` repository:**
     ```bash
-    git clone <your-repo-url> # Replace <your-repo-url> with the actual repository URL
-    cd invoxa # Or your cloned directory name, e.g., invoxa-cli
+    git clone <your-repo-url> # Replace <your-repo-url>
+    cd invoxa-cli # Or your cloned directory name
     ```
 2.  **Install dependencies for the CLI tool itself:**
-    This step is crucial to install `fs-extra` and other dependencies.
     ```bash
     npm install
     ```
+    (This installs `fs-extra`, `inquirer`, etc.)
 3.  **Link the package:**
-    This makes the `invoxa` command (as defined in `package.json`'s `bin`) available globally on your system, pointing to your local project files.
+    This makes your local version of the `invoxa` command globally available.
     ```bash
     npm link
     ```
-    Verify by typing `invoxa` in a new terminal tab/window; it should show the help message if no project name is provided.
-
-4.  **Test the command:**
-    Navigate to a *different* directory where you want to create your test project. For example:
-    ```bash
-    mkdir ../cli-test-projects
-    cd ../cli-test-projects
-    ```
-    Now run the linked `invoxa` command with a project name:
-    ```bash
-    invoxa my-sample-app
-    ```
-    You should see a new directory `my-sample-app` created inside `../cli-test-projects`, containing the template files. Check its contents.
-
-5.  **Making changes and re-testing:**
-    If you make changes to `index.js` or other files in the `invoxa` project, these changes are immediately live in your linked `invoxa` command because `npm link` creates a symbolic link. Simply re-run the command in your test directory.
-
-6.  **Unlinking:**
-    When you're done testing, you might want to remove the global link.
-    From within the `invoxa` project directory, run:
+4.  **Test Project Creation:**
+    *   Navigate to a separate test directory (e.g., `mkdir ../my-cli-tests && cd ../my-cli-tests`).
+    *   Test creation with argument: `invoxa test-project-arg`
+    *   Test creation interactively: `invoxa` (and enter a name like `test-project-interactive`).
+5.  **Test Project Management & Module Installation:**
+    *   `cd test-project-arg` (or your chosen project name).
+    *   Run `invoxa` to open the interactive menu. Test module installation via the menu.
+    *   Test direct module installation: `invoxa install:pterodactyl` (assuming 'pterodactyl' is an available module in your CLI's `template/modules/`).
+    *   Verify that modules are copied to `test-project-arg/modules/pterodactyl/`.
+6.  **Making changes and re-testing:**
+    Changes to your local `invoxa-cli` source code are immediately reflected in the linked `invoxa` command.
+7.  **Unlinking:**
+    From within the `invoxa-cli` project directory:
     ```bash
     npm unlink
     ```
-    This removes the global link for `invoxa` that was pointing to this local project. If you also installed it globally for testing from a registry, you might need `npm uninstall -g invoxa`.
+    (To remove the global link. You might also need `npm uninstall -g invoxa` if you globally installed a published version for testing.)
 
 ## Publishing to npmjs.com
 
@@ -105,11 +148,3 @@ This will create a new directory named `my-new-project` (or your chosen project 
     ```bash
     npm publish --otp=123456
     ```
-
-## Project Template
-
-The generated project (e.g., `my-sample-app/`) will have the following basic structure:
-
--   `index.html`: Main HTML file.
--   `src/`: Directory for your source code.
--   `README.md`: A README for the generated project.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "fs-extra": "^10.0.0"
+    "fs-extra": "^10.0.0",
+    "inquirer": "^8.2.4"
   },
   "repository": {
     "type": "git",

--- a/template/invoxa/README.md
+++ b/template/invoxa/README.md
@@ -1,0 +1,5 @@
+# Invoza Core Project (Remix.run)
+
+Please replace the contents of this directory (template/invoxa/)
+with your actual Remix.run project files that will be scaffolded
+when a new Invoza project is created.

--- a/template/modules/proxmox/README.md
+++ b/template/modules/proxmox/README.md
@@ -1,0 +1,5 @@
+# Proxmox Module
+
+These are the files for the Proxmox module.
+They will be copied into the 'modules/proxmox/' directory
+of an existing Invoza project.

--- a/template/modules/pterodactyl/README.md
+++ b/template/modules/pterodactyl/README.md
@@ -1,0 +1,5 @@
+# Pterodactyl Module
+
+These are the files for the Pterodactyl module.
+They will be copied into the 'modules/pterodactyl/' directory
+of an existing Invoza project.


### PR DESCRIPTION
This commit introduces a major enhancement to the Invoza CLI, making it interactive and adding support for module installation.

Key Features:

1.  **Interactive Project Creation**:
    - If `invoxa` (or `npx invoxa@latest`) is run without a project name, it now interactively prompts you for one using `inquirer`.
    - The main Invoza application (expected to be a Remix.run project) is scaffolded from the `template/invoxa/` directory within the CLI package.
    - A `.invoza-project-marker` file is created in the root of new projects for reliable project detection.

2.  **Module Installation**:
    - You can install modules into an existing Invoza project.
    - Modules are sourced from `template/modules/<module-name>/` directories within the CLI package.
    - Installed modules are copied into the `<project-root>/modules/` directory.
    - **Direct Command**: `invoxa install:<module-name>` (e.g., `invoxa install:pterodactyl`) can be run from within an Invoza project.
    - **Interactive Menu**: Running `invoxa` without arguments inside an Invoza project now opens an interactive menu.
      - The menu allows you to select and install available modules.
      - Modules are dynamically listed by scanning `template/modules/`.

3.  **Updated Template Structure**:
    - `template/invoxa/`: Designated for the core Invoza Remix.run project template.
    - `template/modules/`: Contains subdirectories for each installable module (e.g., `pterodactyl`, `proxmox`).

4.  **Enhanced `README.md`**:
    - Comprehensively updated to document all new interactive features, commands, the template structure, and local testing procedures.

Dependencies:
- Added `inquirer` for command-line prompts.